### PR TITLE
Goodbye to CRC checks! (sv_pure bypass)

### DIFF
--- a/Osiris/EventListener.cpp
+++ b/Osiris/EventListener.cpp
@@ -34,6 +34,7 @@ namespace
                 InventoryChanger::overrideHudIcon(*event);
                 Misc::killMessage(*event);
                 Misc::killSound(*event);
+                Misc::damageList(event);
                 break;
             case fnv::hash("player_hurt"):
                 Misc::playHitSound(*event);

--- a/Osiris/EventListener.cpp
+++ b/Osiris/EventListener.cpp
@@ -37,6 +37,7 @@ namespace
                 Misc::damageList(event);
                 break;
             case fnv::hash("player_hurt"):
+                Misc::damageList(event);
                 Misc::playHitSound(*event);
                 Visuals::hitEffect(event);
                 Visuals::hitMarker(event);

--- a/Osiris/EventListener.cpp
+++ b/Osiris/EventListener.cpp
@@ -21,6 +21,7 @@ namespace
         {
             switch (fnv::hashRuntime(event->getName())) {
             case fnv::hash("round_start"):
+                Misc::damageList(event);
                 GameData::clearProjectileList();
                 Misc::preserveKillfeed(true);
                 [[fallthrough]];

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -1969,6 +1969,7 @@ static void from_json(const json& j, MiscConfig& m)
     read(j, "Name stealer", m.nameStealer);
     read(j, "Disable HUD blur", m.disablePanoramablur);
     read(j, "Ban color", m.banColor);
+    read<value_t::object>(j, "Damage list", m.damageList);
     read<value_t::string>(j, "Ban text", m.banText);
     read(j, "Fast plant", m.fastPlant);
     read(j, "Fast Stop", m.fastStop);

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -2011,6 +2011,15 @@ static void from_json(const json& j, MiscConfig::Reportbot& r)
     read(j, "Other Hacking", r.other);
 }
 
+static void from_json(const json& j, MiscConfig::DamageList& dl)
+{
+    read(j, "Enabled", dl.enabled);
+    read(j, "No Title Bar", dl.noTitleBar);
+    read<value_t::object>(j, "Pos", dl.pos);
+    read<value_t::object>(j, "Size", dl.size);
+    read(j, "Max rows", dl.maxRows);
+}
+
 static void to_json(json& j, const MiscConfig::Reportbot& o, const MiscConfig::Reportbot& dummy = {})
 {
     WRITE("Enabled", enabled);
@@ -2057,13 +2066,18 @@ static void to_json(json& j, const MiscConfig::SpectatorList& o, const MiscConfi
     }
 }
 
-static void from_json(const json& j, MiscConfig::DamageList& dl)
+
+
+static void to_json(json& j, const MiscConfig::DamageList& o, const MiscConfig::DamageList& dummy = {})
 {
-    read(j, "Enabled", dl.enabled);
-    read(j, "No Title Bar", dl.noTitleBar);
-    read<value_t::object>(j, "Pos", dl.pos);
-    read<value_t::object>(j, "Size", dl.size);
-    read(j, "Max rows", dl.maxRows);
+    WRITE("Enabled", enabled);
+    WRITE("No Title Bar", noTitleBar);
+    WRITE("Max rows", maxRows);
+
+    if (const auto window = ImGui::FindWindowByName("Damage list")) {
+        j["Pos"] = window->Pos;
+        j["Size"] = window->SizeFull;
+    }
 }
 
 static void to_json(json& j, const MiscConfig::Watermark& o, const MiscConfig::Watermark& dummy = {})

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -134,6 +134,16 @@ struct MiscConfig {
         ImVec2 pos;
         ImVec2 size{ 200.0f, 200.0f };
     };
+    
+    
+    struct DamageList {
+        bool enabled = false;
+        bool noTitleBar = false;
+        int maxRows = 3;
+        ImVec2 pos;
+        ImVec2 size{ 300.0f, 200.0f };
+    };
+    DamageList damageList;
 
     SpectatorList spectatorList;
     struct Watermark {

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -1680,6 +1680,23 @@ void Misc::drawGUI(bool contentOnly) noexcept
         ImGui::EndPopup();
     }
     ImGui::PopID();
+    
+    ImGui::Checkbox("Damage list", &miscConfig.damageList.enabled);
+    ImGui::SameLine();
+
+    ImGui::PushID("Damage list");
+    if (ImGui::Button("..."))
+        ImGui::OpenPopup("");
+
+    if (ImGui::BeginPopup("")) {
+        ImGui::Checkbox("No Title Bar", &miscConfig.damageList.noTitleBar);
+        miscConfig.damageList.maxRows = std::clamp(miscConfig.damageList.maxRows, 1, 64);
+        ImGui::PushItemWidth(100.0f);
+        ImGui::InputInt("Maximum rows", &miscConfig.damageList.maxRows);
+        ImGui::PopItemWidth();
+        ImGui::EndPopup();
+    }
+    ImGui::PopID();
 
     ImGui::Checkbox("Watermark", &miscConfig.watermark.enabled);
     ImGuiCustom::colorPicker("Offscreen Enemies", miscConfig.offscreenEnemies.asColor4(), &miscConfig.offscreenEnemies.enabled);

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -2056,6 +2056,15 @@ static void to_json(json& j, const MiscConfig::SpectatorList& o, const MiscConfi
     }
 }
 
+static void from_json(const json& j, MiscConfig::DamageList& dl)
+{
+    read(j, "Enabled", dl.enabled);
+    read(j, "No Title Bar", dl.noTitleBar);
+    read<value_t::object>(j, "Pos", dl.pos);
+    read<value_t::object>(j, "Size", dl.size);
+    read(j, "Max rows", dl.maxRows);
+}
+
 static void to_json(json& j, const MiscConfig::Watermark& o, const MiscConfig::Watermark& dummy = {})
 {
     WRITE("Enabled", enabled);

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -2161,6 +2161,7 @@ static void to_json(json& j, const MiscConfig& o)
     WRITE("Opposite Hand Knife", oppositeHandKnife);
     WRITE("Preserve Killfeed", preserveKillfeed);
     WRITE("Force relay cluster", forceRelayCluster);
+    WRITE("Damage list", damageList);
 }
 
 json Misc::toJson() noexcept

--- a/Osiris/Hacks/Misc.h
+++ b/Osiris/Hacks/Misc.h
@@ -58,6 +58,7 @@ namespace Misc
     void playHitSound(GameEvent& event) noexcept;
     void killSound(GameEvent& event) noexcept;
     void purchaseList(GameEvent* event = nullptr) noexcept;
+    void damageList(GameEvent* event = nullptr) noexcept;
   
     void oppositeHandKnife(FrameStage stage) noexcept;
     void runReportbot() noexcept;

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -339,6 +339,11 @@ static bool __FASTCALL svCheatsGetBool(void* _this) noexcept
 
     return hooks->svCheats.getOriginal<bool, WIN32_LINUX(13, 16)>()(_this);
 }
+    
+static int __STDCALL hkFileCRCGoByeBye(void* _this)
+{
+    return 0;
+}
 
 static void __STDCALL frameStageNotify(LINUX_ARGS(void* thisptr,) FrameStage stage) noexcept
 {
@@ -707,6 +712,9 @@ void Hooks::install() noexcept
     viewRender.init(memory->viewRender);
     viewRender.hookAt(WIN32_LINUX(39, 40), &render2dEffectsPreHud);
     viewRender.hookAt(WIN32_LINUX(41, 42), &renderSmokeOverlay);
+    
+    svPure.init(interfaces->fullFileSystem);
+    svPure.hookAt(WIN32_LINUX(101, 102), reinterpret_cast<void*>(hkFileCRCGoByeBye));
 
 #ifdef _WIN32
     if (DWORD oldProtection; VirtualProtect(memory->dispatchSound, 4, PAGE_EXECUTE_READWRITE, &oldProtection)) {
@@ -775,6 +783,7 @@ void Hooks::uninstall() noexcept
     surface.restore();
     svCheats.restore();
     viewRender.restore();
+    svPure.restore();
     networkChannel.restore();
 
     Netvars::restore();

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -161,6 +161,7 @@ static void swapWindow(SDL_Window * window) noexcept
     if (const auto& displaySize = ImGui::GetIO().DisplaySize; displaySize.x > 0.0f && displaySize.y > 0.0f) {
         StreamProofESP::render();
         Misc::purchaseList();
+        Misc::damageList();
         Misc::noscopeCrosshair(ImGui::GetBackgroundDrawList());
         Misc::recoilCrosshair(ImGui::GetBackgroundDrawList());
         Misc::drawOffscreenEnemies(ImGui::GetBackgroundDrawList());

--- a/Osiris/Hooks.h
+++ b/Osiris/Hooks.h
@@ -62,6 +62,7 @@ public:
     VmtSwap networkChannel;
     HookType viewRender;
     HookType svCheats;
+    HookType svPure;
 private:
 #ifdef _WIN32
     HMODULE moduleHandle;

--- a/Osiris/Interfaces.h
+++ b/Osiris/Interfaces.h
@@ -64,6 +64,7 @@ type* name = reinterpret_cast<type*>(find(moduleName, version));
     GAME_INTERFACE(EngineSound, sound, ENGINE_DLL, "IEngineSoundClient003")
     GAME_INTERFACE(SoundEmitter, soundEmitter, SOUNDEMITTERSYSTEM_DLL, "VSoundEmitter003")
     GAME_INTERFACE(StudioRender, studioRender, STUDIORENDER_DLL, "VStudioRender026")
+    GAME_INTERFACE(BaseFileSystem, fullFileSystem, FILESYSTEM_DLL, "VFileSystem017")
 
 #undef GAME_INTERFACE
 private:


### PR DESCRIPTION
This sv_pure bypass works by disabling file CRC checks that check to see if a file is modified.
The checking is hooked at injection stage so it shouldn't bother anyone too much. I was going to add a misc checkbox for this but I decided not to.

EDIT: Please keep in mind that this is still in testing. Though it works on my system, it may not work for others. I am still getting data from other users.